### PR TITLE
Add GitHub Pages deploy workflow

### DIFF
--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -13,7 +13,7 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - uses: actions/upload-pages-artifact@v3
-        with: { path: "." }   # root has index.html
+        with: { path: "." }
   deploy:
     needs: build
     runs-on: ubuntu-latest

--- a/README.md
+++ b/README.md
@@ -1,2 +1,7 @@
 # material001
 Material App 001: People Counter
+
+## Live site
+
+Pushes to the `main` branch automatically deploy to GitHub Pages.
+The site is available at `https://<user>.github.io/material001/`.


### PR DESCRIPTION
## Summary
- deploy static site to GitHub Pages on pushes to `main`
- document live site URL in README

## Testing
- `python3 -m http.server 8000 &` + `curl -I -s http://localhost:8000/`


------
https://chatgpt.com/codex/tasks/task_e_68993bf193b8833384a0a978d2ec4724