### PR TITLE
docs: add quickstart README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,23 @@
-# material001
-Material App 001: People Counter
+# People Counter (Material)
 
-## Live site
+## Overview
+A zero-training, offline-first people counter for events. Supports multiple counters (e.g., Main Entrance, Terrace Stairs), per-counter capacity/lockout, offline queue + optional sync to a Google Apps Script endpoint. CSV export included.
 
-Pushes to the `main` branch automatically deploy to GitHub Pages.
-The site is available at `https://<user>.github.io/material001/`.
+## Live URL
+https://bwsmx.github.io/material001/
+
+## Run locally
+```bash
+python3 -m http.server 8000
+# open http://localhost:8000
+```
+
+## Configure
+Open the ⚙️ menu (PIN 1234) to add counters, set capacity, or configure an optional Google Apps Script endpoint.
+
+## Privacy
+All data is stored locally in your browser. If you configure an endpoint, counts are queued locally and sent to that endpoint when online.
+
+## Deployment
+Static HTML; host index.html on any static file server. Pushes to the `main` branch are automatically deployed to GitHub Pages.
+


### PR DESCRIPTION
## Summary
- add concise README with live URL, run instructions, config and privacy notes

## Testing
- `python3 -m http.server 8000`
- `curl -I http://localhost:8000/index.html`


------
https://chatgpt.com/codex/tasks/task_e_68994275b7648333b0334f51352f387e