### PR TITLE
docs: clarify Pages deployment

### DIFF
--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -1,21 +1,27 @@
 # .github/workflows/pages.yml
 name: Deploy static site to Pages
 on:
-  push: { branches: [ main ] }
+  push:
+    branches: [ main ]
   workflow_dispatch:
 permissions:
   contents: read
   pages: write
   id-token: write
+concurrency:
+  group: "pages"
+  cancel-in-progress: true
 jobs:
-  build:
+  deploy:
     runs-on: ubuntu-latest
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
     steps:
       - uses: actions/checkout@v4
+      - uses: actions/configure-pages@v5
       - uses: actions/upload-pages-artifact@v3
-        with: { path: "." }
-  deploy:
-    needs: build
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/deploy-pages@v4
+        with:
+          path: "."
+      - id: deployment
+        uses: actions/deploy-pages@v4

--- a/README.md
+++ b/README.md
@@ -21,3 +21,10 @@ All data is stored locally in your browser. If you configure an endpoint, counts
 ## Deployment
 Static HTML; host index.html on any static file server. Pushes to the `main` branch are automatically deployed to GitHub Pages.
 
+### GitHub Pages (GitHub Actions)
+
+- In repo **Settings → Pages**, set **Build and deployment → Source = GitHub Actions**.
+- Merging to `main` triggers the deploy workflow.
+- Live URL: https://bwsmx.github.io/material001/
+- If a deploy fails with 404 from `deploy-pages`, confirm the Pages Source is **GitHub Actions** and re-run the workflow.
+


### PR DESCRIPTION
## Summary
- configure workflow for reliable GitHub Pages deploys via Actions
- document Pages deployment settings in README

## Testing
- `python3 -m http.server 8000 & curl -I http://localhost:8000/index.html`


------
https://chatgpt.com/codex/tasks/task_e_68994e814554833386eb1f49f782cd22